### PR TITLE
Fix issue #1 "Running solution on Linux casuses issue with the path error for currencies.txt"

### DIFF
--- a/AITravelAgent/Solution/Plugins/ConvertCurrency/Currency.cs
+++ b/AITravelAgent/Solution/Plugins/ConvertCurrency/Currency.cs
@@ -32,8 +32,8 @@ public class Currency
         currencyDictionary = [];
 
         string filePath = Path.Combine(
-            Directory.GetCurrentDirectory(), 
-            "Plugins\\ConvertCurrency\\currencies.txt"
+            Directory.GetCurrentDirectory(),
+             "Plugins", "ConvertCurrency", "currencies.txt"
         );
         
         if (!File.Exists(filePath))


### PR DESCRIPTION
Remove "\\" escaping from folder definition and use the right signature of the method Path.Combine().
Fix issue #1 